### PR TITLE
specify module dependencies

### DIFF
--- a/PSCodeHealth/PSCodeHealth.psd1
+++ b/PSCodeHealth/PSCodeHealth.psd1
@@ -48,8 +48,16 @@ PowerShellVersion = '5.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('Pester','PSScriptAnalyzer')
-
+RequiredModules = @(
+    @{
+        ModuleName = 'Pester'
+        ModuleVersion = '4.10.1'
+    },
+    @{
+        ModuleName = 'PSScriptAnalyzer'
+        ModuleVersion= '1.19.0'
+    }
+)
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
 


### PR DESCRIPTION
Pester released their new v5 version which is not 100% compatible with the v4 parameters

## Description
Pester 5 ist not compatible with the hashtable format for providing multiple src & test files.
So for now it's easier to stick with 4.10.1 until 5.1 ++ it is released..

## Related Issue
See https://github.com/pester/Pester#actual-breaking-changes for hashtable issue

## Motivation and Context
It fixes fresh PSCodeHealth installations.

## How Has This Been Tested?
tested locally with internal gitea + drone pipeline...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.